### PR TITLE
Generate a recipe received from scheme URL

### DIFF
--- a/NefEditorClient.xcodeproj/project.pbxproj
+++ b/NefEditorClient.xcodeproj/project.pbxproj
@@ -309,7 +309,6 @@
 		8B06E8CD246D5361008C7189 /* SectionTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionTitle.swift; sourceTree = "<group>"; };
 		8B3FEAEE246DA3FE00642BF3 /* LottieAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LottieAnimation.swift; sourceTree = "<group>"; };
 		8B3FEAF0246DA41900642BF3 /* Animations */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Animations; sourceTree = "<group>"; };
-		8B7090E5248BF25F0088A773 /* bow-arch */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "bow-arch"; path = "../bow-arch"; sourceTree = "<group>"; };
 		8B787846246ECD9D003828F0 /* GenerationPlaygroundBookView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationPlaygroundBookView.swift; sourceTree = "<group>"; };
 		8B87B420248E4A6C007372EC /* URLQueryItem+Recipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLQueryItem+Recipe.swift"; sourceTree = "<group>"; };
 		8B87B422248E82A3007372EC /* DeepLinkAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkAction.swift; sourceTree = "<group>"; };
@@ -628,7 +627,6 @@
 			children = (
 				11EDF467243714210092E959 /* github.yaml */,
 				11FE7AE3246A99D40011DB41 /* nef.yaml */,
-				8B7090E5248BF25F0088A773 /* bow-arch */,
 				11CDD931247444AD0002E45F /* GitHub */,
 				11CDD930247444AD0002E45F /* NefAPI */,
 				1163838224321FD100EB2DEF /* NefEditorClient */,

--- a/NefEditorClient.xcodeproj/project.pbxproj
+++ b/NefEditorClient.xcodeproj/project.pbxproj
@@ -162,6 +162,9 @@
 		8B3FEAF1246DA41900642BF3 /* Animations in Resources */ = {isa = PBXBuildFile; fileRef = 8B3FEAF0246DA41900642BF3 /* Animations */; };
 		8B787847246ECD9D003828F0 /* GenerationPlaygroundBookView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B787846246ECD9D003828F0 /* GenerationPlaygroundBookView.swift */; };
 		8B87B421248E4A6C007372EC /* URLQueryItem+Recipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B87B420248E4A6C007372EC /* URLQueryItem+Recipe.swift */; };
+		8B87B426248E838F007372EC /* DeepLinkDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B87B425248E838F007372EC /* DeepLinkDispatcher.swift */; };
+		8B87B427248E8486007372EC /* DeepLinkAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B87B422248E82A3007372EC /* DeepLinkAction.swift */; };
+		8B87B42B248E852F007372EC /* DeepLinkState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B87B42A248E852F007372EC /* DeepLinkState.swift */; };
 		8BC3C90B246D7A2600EC9F36 /* GenerationSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC3C90A246D7A2600EC9F36 /* GenerationSuccessView.swift */; };
 /* End PBXBuildFile section */
 
@@ -309,6 +312,9 @@
 		8B7090E5248BF25F0088A773 /* bow-arch */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "bow-arch"; path = "../bow-arch"; sourceTree = "<group>"; };
 		8B787846246ECD9D003828F0 /* GenerationPlaygroundBookView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationPlaygroundBookView.swift; sourceTree = "<group>"; };
 		8B87B420248E4A6C007372EC /* URLQueryItem+Recipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLQueryItem+Recipe.swift"; sourceTree = "<group>"; };
+		8B87B422248E82A3007372EC /* DeepLinkAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkAction.swift; sourceTree = "<group>"; };
+		8B87B425248E838F007372EC /* DeepLinkDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkDispatcher.swift; sourceTree = "<group>"; };
+		8B87B42A248E852F007372EC /* DeepLinkState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkState.swift; sourceTree = "<group>"; };
 		8BC3C90A246D7A2600EC9F36 /* GenerationSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationSuccessView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -654,6 +660,7 @@
 				1139BF9B24645B0000BC283A /* Authentication */,
 				11AD8DCA243DC42E0005E450 /* Catalog */,
 				1139BF8724641C9D00BC283A /* Credits */,
+				8B87B424248E8380007372EC /* DeepLink */,
 				11B125BD2447074500E2D1C3 /* Detail */,
 				114AF44D2459863B000116B7 /* Edit */,
 				11E07F14243B218E00A0A027 /* Extensions */,
@@ -932,6 +939,32 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		8B87B424248E8380007372EC /* DeepLink */ = {
+			isa = PBXGroup;
+			children = (
+				8B87B429248E8517007372EC /* State */,
+				8B87B428248E8512007372EC /* Logic */,
+			);
+			path = DeepLink;
+			sourceTree = "<group>";
+		};
+		8B87B428248E8512007372EC /* Logic */ = {
+			isa = PBXGroup;
+			children = (
+				8B87B422248E82A3007372EC /* DeepLinkAction.swift */,
+				8B87B425248E838F007372EC /* DeepLinkDispatcher.swift */,
+			);
+			path = Logic;
+			sourceTree = "<group>";
+		};
+		8B87B429248E8517007372EC /* State */ = {
+			isa = PBXGroup;
+			children = (
+				8B87B42A248E852F007372EC /* DeepLinkState.swift */,
+			);
+			path = State;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -1105,6 +1138,7 @@
 				1139BF8624640D3800BC283A /* ICloudStatus.swift in Sources */,
 				1142543D2448A80900B2EA0C /* RepositoryDetailAction.swift in Sources */,
 				11E07F18243B353500A0A027 /* SearchBar.swift in Sources */,
+				8B87B42B248E852F007372EC /* DeepLinkState.swift in Sources */,
 				11B125C02447077000E2D1C3 /* DependencyView.swift in Sources */,
 				1155FDCD246D26E900F5F819 /* MainDispatcher.swift in Sources */,
 				114AF44C24597675000116B7 /* View+Modal.swift in Sources */,
@@ -1186,6 +1220,7 @@
 				112EA4E824618EC700F91DBA /* Persistence.swift in Sources */,
 				1150CDC7246B0D8D003509B4 /* ActivityViewController.swift in Sources */,
 				1107028D243C9A25008583EB /* AnimationView.swift in Sources */,
+				8B87B427248E8486007372EC /* DeepLinkAction.swift in Sources */,
 				114AF45424598736000116B7 /* EditDispatcher.swift in Sources */,
 				11AD8DD7243E19440005E450 /* Dependency.swift in Sources */,
 				11070289243C81DC008583EB /* RequirementView.swift in Sources */,
@@ -1211,6 +1246,7 @@
 				11EDF44D2435F5410092E959 /* SearchView.swift in Sources */,
 				1101A3AC245AB5F6002A848B /* URLImage.swift in Sources */,
 				114AF45C24598E15000116B7 /* CatalogDetailDispatcher.swift in Sources */,
+				8B87B426248E838F007372EC /* DeepLinkDispatcher.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NefEditorClient.xcodeproj/project.pbxproj
+++ b/NefEditorClient.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		8B3FEAEF246DA3FE00642BF3 /* LottieAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3FEAEE246DA3FE00642BF3 /* LottieAnimation.swift */; };
 		8B3FEAF1246DA41900642BF3 /* Animations in Resources */ = {isa = PBXBuildFile; fileRef = 8B3FEAF0246DA41900642BF3 /* Animations */; };
 		8B787847246ECD9D003828F0 /* GenerationPlaygroundBookView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B787846246ECD9D003828F0 /* GenerationPlaygroundBookView.swift */; };
+		8B84D96A248F8B3B003877B1 /* UIOpenURLContext+Recipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B84D969248F8B3B003877B1 /* UIOpenURLContext+Recipe.swift */; };
 		8B87B421248E4A6C007372EC /* URLQueryItem+Recipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B87B420248E4A6C007372EC /* URLQueryItem+Recipe.swift */; };
 		8B87B426248E838F007372EC /* DeepLinkDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B87B425248E838F007372EC /* DeepLinkDispatcher.swift */; };
 		8B87B427248E8486007372EC /* DeepLinkAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B87B422248E82A3007372EC /* DeepLinkAction.swift */; };
@@ -310,6 +311,7 @@
 		8B3FEAEE246DA3FE00642BF3 /* LottieAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LottieAnimation.swift; sourceTree = "<group>"; };
 		8B3FEAF0246DA41900642BF3 /* Animations */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Animations; sourceTree = "<group>"; };
 		8B787846246ECD9D003828F0 /* GenerationPlaygroundBookView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationPlaygroundBookView.swift; sourceTree = "<group>"; };
+		8B84D969248F8B3B003877B1 /* UIOpenURLContext+Recipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIOpenURLContext+Recipe.swift"; sourceTree = "<group>"; };
 		8B87B420248E4A6C007372EC /* URLQueryItem+Recipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLQueryItem+Recipe.swift"; sourceTree = "<group>"; };
 		8B87B422248E82A3007372EC /* DeepLinkAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkAction.swift; sourceTree = "<group>"; };
 		8B87B425248E838F007372EC /* DeepLinkDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkDispatcher.swift; sourceTree = "<group>"; };
@@ -929,6 +931,14 @@
 			path = Logic;
 			sourceTree = "<group>";
 		};
+		8B84D968248F8B2F003877B1 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				8B84D969248F8B3B003877B1 /* UIOpenURLContext+Recipe.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		8B87B41F248E4A5D007372EC /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -940,6 +950,7 @@
 		8B87B424248E8380007372EC /* DeepLink */ = {
 			isa = PBXGroup;
 			children = (
+				8B84D968248F8B2F003877B1 /* Extensions */,
 				8B87B429248E8517007372EC /* State */,
 				8B87B428248E8512007372EC /* Logic */,
 			);
@@ -1240,6 +1251,7 @@
 				11B125B62444BCAC00E2D1C3 /* Catalog.swift in Sources */,
 				11E07F11243B118F00A0A027 /* GridView.swift in Sources */,
 				11FE7AC824659BAC0011DB41 /* GenerationComponent.swift in Sources */,
+				8B84D96A248F8B3B003877B1 /* UIOpenURLContext+Recipe.swift in Sources */,
 				1163BA95244ED043005B0785 /* AppAction.swift in Sources */,
 				11EDF44D2435F5410092E959 /* SearchView.swift in Sources */,
 				1101A3AC245AB5F6002A848B /* URLImage.swift in Sources */,

--- a/NefEditorClient.xcodeproj/project.pbxproj
+++ b/NefEditorClient.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		8B3FEAEF246DA3FE00642BF3 /* LottieAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3FEAEE246DA3FE00642BF3 /* LottieAnimation.swift */; };
 		8B3FEAF1246DA41900642BF3 /* Animations in Resources */ = {isa = PBXBuildFile; fileRef = 8B3FEAF0246DA41900642BF3 /* Animations */; };
 		8B787847246ECD9D003828F0 /* GenerationPlaygroundBookView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B787846246ECD9D003828F0 /* GenerationPlaygroundBookView.swift */; };
+		8B87B421248E4A6C007372EC /* URLQueryItem+Recipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B87B420248E4A6C007372EC /* URLQueryItem+Recipe.swift */; };
 		8BC3C90B246D7A2600EC9F36 /* GenerationSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC3C90A246D7A2600EC9F36 /* GenerationSuccessView.swift */; };
 /* End PBXBuildFile section */
 
@@ -305,7 +306,9 @@
 		8B06E8CD246D5361008C7189 /* SectionTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionTitle.swift; sourceTree = "<group>"; };
 		8B3FEAEE246DA3FE00642BF3 /* LottieAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LottieAnimation.swift; sourceTree = "<group>"; };
 		8B3FEAF0246DA41900642BF3 /* Animations */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Animations; sourceTree = "<group>"; };
+		8B7090E5248BF25F0088A773 /* bow-arch */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "bow-arch"; path = "../bow-arch"; sourceTree = "<group>"; };
 		8B787846246ECD9D003828F0 /* GenerationPlaygroundBookView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationPlaygroundBookView.swift; sourceTree = "<group>"; };
+		8B87B420248E4A6C007372EC /* URLQueryItem+Recipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLQueryItem+Recipe.swift"; sourceTree = "<group>"; };
 		8BC3C90A246D7A2600EC9F36 /* GenerationSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationSuccessView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -619,6 +622,7 @@
 			children = (
 				11EDF467243714210092E959 /* github.yaml */,
 				11FE7AE3246A99D40011DB41 /* nef.yaml */,
+				8B7090E5248BF25F0088A773 /* bow-arch */,
 				11CDD931247444AD0002E45F /* GitHub */,
 				11CDD930247444AD0002E45F /* NefAPI */,
 				1163838224321FD100EB2DEF /* NefEditorClient */,
@@ -741,6 +745,7 @@
 			isa = PBXGroup;
 			children = (
 				11C95ABB24584D8C00659C97 /* Component */,
+				8B87B41F248E4A5D007372EC /* Extensions */,
 				11C95AB624584B6100659C97 /* Logic */,
 				11AD8DD3243E19130005E450 /* State */,
 				11AD8DCB243DC46C0005E450 /* View */,
@@ -917,6 +922,14 @@
 				11FE7ACE2465B8930011DB41 /* GenerationDispatcher.swift */,
 			);
 			path = Logic;
+			sourceTree = "<group>";
+		};
+		8B87B41F248E4A5D007372EC /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				8B87B420248E4A6C007372EC /* URLQueryItem+Recipe.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1152,6 +1165,7 @@
 				1139BFA124645F3400BC283A /* AuthenticationInfo.swift in Sources */,
 				1139BFA52464609600BC283A /* GenerationView.swift in Sources */,
 				1155FDD3246D2D0100F5F819 /* AppModalComponent.swift in Sources */,
+				8B87B421248E4A6C007372EC /* URLQueryItem+Recipe.swift in Sources */,
 				11B125C424471E1C00E2D1C3 /* ActionButtonStyle.swift in Sources */,
 				11FE7AC4246583B80011DB41 /* GenerationState.swift in Sources */,
 				11C95ABA24584BE300659C97 /* CatalogDispatcher.swift in Sources */,

--- a/NefEditorClient.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NefEditorClient.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/bow-swift/bow-arch.git",
         "state": {
           "branch": "master",
-          "revision": "f4079c898a37665811ec109b157721841c946cbc",
+          "revision": "248beec607e9cf060cf5164d27321db6bdc6cf51",
           "version": null
         }
       },
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/47deg/nef-editor-server",
         "state": {
           "branch": "master",
-          "revision": "434096eb250a9da3e0f4d20c920a2c4bb294fc7e",
+          "revision": "e37abf8358ead40695c2a9e1acffb6135bd4a7ed",
           "version": null
         }
       },

--- a/NefEditorClient/AppDelegate.swift
+++ b/NefEditorClient/AppDelegate.swift
@@ -29,7 +29,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-
 }
-

--- a/NefEditorClient/Catalog/Extensions/URLQueryItem+Recipe.swift
+++ b/NefEditorClient/Catalog/Extensions/URLQueryItem+Recipe.swift
@@ -1,28 +1,25 @@
 import Foundation
 
 extension Array where Element == URLQueryItem {
-    private func value(of key: String) -> String {
-        first { $0.name == key }?.value ?? ""
+    private func value(of key: String) -> String? {
+        first { $0.name == key }?.value
     }
     
     var recipe: Recipe? {
-        let title = value(of: "name")
-        let description = value(of: "description")
+        guard let title = value(of: "name"),
+              let dependency = dependency else { return nil }
         
-        guard !title.isEmpty, let dependency = dependency else { return nil }
-        
-        return Recipe(title: title,
-                      description: description,
-                      dependencies: [dependency])
+        return .init(title: title,
+                     description: value(of: "description") ?? "",
+                     dependencies: [dependency])
     }
     
     var dependency: Dependency? {
-        let repository = value(of: "name")
-        let url = value(of: "url")
-        let owner = value(of: "owner")
-        let avatar = value(of: "avatar")
-        
-        guard !repository.isEmpty, !url.isEmpty, let requirement = requirement else { return nil }
+        guard let repository = value(of: "name"),
+              let url = value(of: "url"),
+              let owner = value(of: "owner"),
+              let avatar = value(of: "avatar"),
+              let requirement = requirement else { return nil }
         
         return .init(repository: repository,
                      owner: owner,
@@ -32,12 +29,9 @@ extension Array where Element == URLQueryItem {
     }
     
     var requirement: Requirement? {
-        let branch = value(of: "branch")
-        let tag = value(of: "tag")
-        
-        if !branch.isEmpty {
+        if let branch = value(of: "branch") {
             return .branch(.init(name: branch))
-        } else if !tag.isEmpty {
+        } else if let tag = value(of: "tag") {
             return .version(.init(name: tag))
         } else {
             return nil

--- a/NefEditorClient/Catalog/Extensions/URLQueryItem+Recipe.swift
+++ b/NefEditorClient/Catalog/Extensions/URLQueryItem+Recipe.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+extension Array where Element == URLQueryItem {
+    private func value(of key: String) -> String {
+        first { $0.name == key }?.value ?? ""
+    }
+    
+    var recipe: Recipe? {
+        let title = value(of: "name")
+        let description = value(of: "description")
+        
+        guard !title.isEmpty, let dependency = dependency else { return nil }
+        
+        return Recipe(title: title,
+                      description: description,
+                      dependencies: [dependency])
+    }
+    
+    var dependency: Dependency? {
+        let repository = value(of: "name")
+        let url = value(of: "url")
+        let owner = value(of: "owner")
+        let avatar = value(of: "avatar")
+        
+        guard !repository.isEmpty, !url.isEmpty, let requirement = requirement else { return nil }
+        
+        return .init(repository: repository,
+                     owner: owner,
+                     url: url,
+                     avatar: avatar,
+                     requirement: requirement)
+    }
+    
+    var requirement: Requirement? {
+        let branch = value(of: "branch")
+        let tag = value(of: "tag")
+        
+        if !branch.isEmpty {
+            return .branch(.init(name: branch))
+        } else if !tag.isEmpty {
+            return .version(.init(name: tag))
+        } else {
+            return nil
+        }
+    }
+}

--- a/NefEditorClient/Credits/Logic/CreditsDispatcher.swift
+++ b/NefEditorClient/Credits/Logic/CreditsDispatcher.swift
@@ -1,7 +1,7 @@
+import UIKit
 import Bow
 import BowArch
 import BowEffects
-import UIKit
 
 typealias CreditsDispatcher = StateDispatcher<Any, AppState, CreditsAction>
 

--- a/NefEditorClient/DeepLink/Extensions/UIOpenURLContext+Recipe.swift
+++ b/NefEditorClient/DeepLink/Extensions/UIOpenURLContext+Recipe.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+func schemeRecipe(urlContexts: Set<UIOpenURLContext>) -> Recipe? {
+    guard let url = urlContexts.first?.url,
+          let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true),
+          let action = components.host,
+          let params = components.queryItems else { return nil }
+    
+    switch action {
+    case "recipe":
+        return params.recipe
+    default:
+        return nil
+    }
+}

--- a/NefEditorClient/DeepLink/Logic/DeepLinkAction.swift
+++ b/NefEditorClient/DeepLink/Logic/DeepLinkAction.swift
@@ -1,0 +1,5 @@
+import BowOptics
+
+enum DeepLinkAction: AutoPrism {
+    case generateRecipe(Recipe)
+}

--- a/NefEditorClient/DeepLink/Logic/DeepLinkAction.swift
+++ b/NefEditorClient/DeepLink/Logic/DeepLinkAction.swift
@@ -2,4 +2,5 @@ import BowOptics
 
 enum DeepLinkAction: AutoPrism {
     case generateRecipe(Recipe)
+    case regularInitialization
 }

--- a/NefEditorClient/DeepLink/Logic/DeepLinkDispatcher.swift
+++ b/NefEditorClient/DeepLink/Logic/DeepLinkDispatcher.swift
@@ -1,0 +1,35 @@
+import UIKit
+import Bow
+import BowEffects
+import BowArch
+
+typealias DeepLinkDispatcher = StateDispatcher<Any, AppState, DeepLinkAction>
+
+let deepLinkDispatcher = DeepLinkDispatcher.workflow { action in
+    switch action {
+    case .generateRecipe(let recipe):
+        return generateNewRecipe(recipe)
+    }
+}
+
+func addNewRecipe(_ recipe: Recipe) -> State<AppState, Void> {
+    .modify { (state: AppState) in
+        let catalogItem: CatalogItem = .regular(recipe)
+        let catalog = state.catalog.appending(catalogItem)
+        return state.copy(catalog: catalog, selectedItem: catalogItem)
+    }^
+}
+
+func emptyDeepLink() -> State<AppState, Void> {
+    .modify { state in
+        state.copy(deepLinkState: DeepLinkState.none)
+    }^
+}
+
+func generateNewRecipe(_ recipe: Recipe) -> [EnvIO<Any, Error, State<AppState, Void>>] {
+    [
+        EnvIO.pure(addNewRecipe(recipe))^,
+        EnvIO.pure(generatePlayground(for: .regular(recipe)))^,
+        EnvIO.pure(emptyDeepLink())^,
+    ]
+}

--- a/NefEditorClient/DeepLink/State/DeepLinkState.swift
+++ b/NefEditorClient/DeepLink/State/DeepLinkState.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum DeepLinkState: Equatable {
+    case none
+    case recipe(Recipe)
+}

--- a/NefEditorClient/Edit/Logic/EditDispatcher.swift
+++ b/NefEditorClient/Edit/Logic/EditDispatcher.swift
@@ -15,33 +15,36 @@ let editDispatcher = EditDispatcher.pure { input in
 
 func saveRecipe(title: String, description: String) -> State<AppState, Void> {
     .modify { state in
-        if let editState = state.modalState.editState {
-            switch editState {
+        guard let editState = state.modalState.editState else { return state }
+        
+        switch editState {
             case .newRecipe:
                 let recipe = createRecipe(title: title, description: description)
-                let newCatalog = state.catalog.appending(recipe)
-                return state.copy(modalState: .noModal, catalog: newCatalog, selectedItem: recipe)
+                return state.addRecipe(recipe)
             
             case .editRecipe(let recipe):
                 let editedRecipe = edit(recipe: recipe, title: title, description: description)
                 let newCatalog = state.catalog.replacing(.regular(recipe), by: .regular(editedRecipe))
                 return state.copy(modalState: .noModal, catalog: newCatalog, selectedItem: .regular(editedRecipe))
             }
-        } else {
-            return state
-        }
     }^
 }
 
-func createRecipe(title: String, description: String) -> CatalogItem {
-    .regular(Recipe(
-        title: title.isEmpty ? "Empty title" : title,
-        description: description,
-        dependencies: []))
+func createRecipe(title: String, description: String) -> Recipe {
+    .init(title: title.isEmpty ? "Empty title" : title,
+          description: description,
+          dependencies: [])
 }
 
 func edit(recipe: Recipe, title: String, description: String) -> Recipe {
-    recipe.copy(
-        title: title.isEmpty ? recipe.title : title,
-        description: description)
+    recipe.copy(title: title.isEmpty ? recipe.title : title,
+                description: description)
+}
+
+extension AppState {
+    func addRecipe(_ recipe: Recipe) -> Self {
+        let catalogItem: CatalogItem = .regular(recipe)
+        let newCatalog = catalog.appending(catalogItem)
+        return self.copy(modalState: .noModal, catalog: newCatalog, selectedItem: catalogItem)
+    }
 }

--- a/NefEditorClient/FAQ/Logic/FAQDispatcher.swift
+++ b/NefEditorClient/FAQ/Logic/FAQDispatcher.swift
@@ -1,8 +1,8 @@
+import UIKit
 import Bow
 import BowEffects
 import BowArch
 import Foundation
-import UIKit
 
 typealias FAQDispatcher = StateDispatcher<Any, AppState, FAQAction>
 

--- a/NefEditorClient/Info.plist
+++ b/NefEditorClient/Info.plist
@@ -16,6 +16,19 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>com.47deg.nef-playgrounds</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>nef-playgrounds</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSApplicationCategoryType</key>

--- a/NefEditorClient/Main/Component/AppComponent.swift
+++ b/NefEditorClient/Main/Component/AppComponent.swift
@@ -14,7 +14,9 @@ typealias AppComponent<Catalog: View, Search: View, Detail: View, Modal: View> =
         AppView<Catalog, Search, Detail, Modal>
     >
 
-func appComponent() -> AppComponent<CatalogComponent, SearchComponent, CatalogDetailComponent, AppModalComponent> {
+typealias AppComponentView = AppComponent<CatalogComponent, SearchComponent, CatalogDetailComponent, AppModalComponent>
+
+func appComponent() -> AppComponentView {
     let initialState = AppState(
         panelState: .catalog,
         modalState: .noModal,
@@ -34,7 +36,7 @@ func appComponent() -> AppComponent<CatalogComponent, SearchComponent, CatalogDe
         nefConfig: nefConfig)
     let ref = IORef<Error, [Recipe]?>.unsafe(nil)
     
-    return AppComponent(
+    return AppComponent (
         initialState: initialState,
         environment: dependencies,
         dispatcher: appDispatcher

--- a/NefEditorClient/Main/Component/AppComponent.swift
+++ b/NefEditorClient/Main/Component/AppComponent.swift
@@ -21,6 +21,7 @@ func appComponent() -> AppComponentView {
         panelState: .catalog,
         modalState: .noModal,
         searchState: SearchState(loadingState: .initial, modalState: .noModal),
+        deepLinkState: .none,
         catalog: Catalog.initial,
         selectedItem: nil,
         iCloudStatus: .enabled,
@@ -90,4 +91,17 @@ func makeNefConfig() -> NefAPI.API.Config {
         basePath: "https://nef.47deg.com",
         session: session)
         .appending(contentType: .json)
+}
+
+var deepLinkAppComponentLens: Lens<AppComponentView, DeepLinkState> {
+    Lens(
+        get: { componentView in
+            AppComponentView.stateLens.get(componentView).deepLinkState
+        },
+        set: { componentView, deepLinkState in
+            let stateLens = AppComponentView.stateLens
+            let appState = stateLens.get(componentView).copy(deepLinkState: deepLinkState)
+            return stateLens.set(componentView, appState)
+        }
+    )
 }

--- a/NefEditorClient/Main/Logic/AppAction.swift
+++ b/NefEditorClient/Main/Logic/AppAction.swift
@@ -8,7 +8,7 @@ enum AppAction: AutoPrism {
     case generationAction(GenerationAction)
     case creditsAction(CreditsAction)
     case faqAction(FAQAction)
-    case initialLoad(DeepLinkAction? = nil)
+    case initialLoad(DeepLinkAction)
     case dismissModal
     case showICloudAlert
     case dismissICloudAlert

--- a/NefEditorClient/Main/Logic/AppAction.swift
+++ b/NefEditorClient/Main/Logic/AppAction.swift
@@ -15,4 +15,5 @@ enum AppAction: AutoPrism {
     case showSettings
     case showCredits
     case showFAQ
+    case schema(Recipe)
 }

--- a/NefEditorClient/Main/Logic/AppAction.swift
+++ b/NefEditorClient/Main/Logic/AppAction.swift
@@ -8,12 +8,11 @@ enum AppAction: AutoPrism {
     case generationAction(GenerationAction)
     case creditsAction(CreditsAction)
     case faqAction(FAQAction)
-    case initialLoad
+    case initialLoad(DeepLinkAction? = nil)
     case dismissModal
     case showICloudAlert
     case dismissICloudAlert
     case showSettings
     case showCredits
     case showFAQ
-    case schema(Recipe)
 }

--- a/NefEditorClient/Main/Logic/AppDispatcher.swift
+++ b/NefEditorClient/Main/Logic/AppDispatcher.swift
@@ -43,5 +43,5 @@ let appDispatcher: AppDispatcher = mainDispatcher
         transformInput: AppAction.prism(for: AppAction.faqAction)))
 
     .combine(deepLinkDispatcher.widen(
-        transformEnvironment: id,
+        transformEnvironment: \.persistence,
         transformInput: AppAction.prism(for: AppAction.initialLoad)))

--- a/NefEditorClient/Main/Logic/AppDispatcher.swift
+++ b/NefEditorClient/Main/Logic/AppDispatcher.swift
@@ -41,3 +41,7 @@ let appDispatcher: AppDispatcher = mainDispatcher
     .combine(faqDispatcher.widen(
         transformEnvironment: id,
         transformInput: AppAction.prism(for: AppAction.faqAction)))
+
+    .combine(deepLinkDispatcher.widen(
+        transformEnvironment: id,
+        transformInput: AppAction.prism(for: AppAction.initialLoad)))

--- a/NefEditorClient/Main/Logic/MainDispatcher.swift
+++ b/NefEditorClient/Main/Logic/MainDispatcher.swift
@@ -36,10 +36,15 @@ let mainDispatcher = MainDispatcher.workflow { action in
         
     case .catalogAction(_), .editAction(_), .catalogDetailAction(_), .creditsAction(_), .generationAction(_), .faqAction(_):
         return []
+        
     case .initialLoad:
         return [initialLoad()]
+        
+    case .schema(let recipe):
+        return generateNewRecipe(recipe)
     }
 }
+
 
 let addDependencyDispatcher = StateDispatcher<Any, AppState, RepositoryDetailAction>.pure { input in
     switch input {
@@ -120,6 +125,14 @@ func addDependency(
     }^
 }
 
+func addNewRecipe(_ recipe: Recipe) -> State<AppState, Void> {
+    .modify { (state: AppState) in
+        let catalogItem: CatalogItem = .regular(recipe)
+        let catalog = state.catalog.appending(catalogItem)
+        return state.copy(catalog: catalog, selectedItem: catalogItem)
+    }^
+}
+
 func persist(state: AppState) -> EnvIO<Persistence, Error, Void> {
     EnvIO.accessM { persistence in
         persistence.saveUserRecipes(state.catalog.userCreated.items.map(\.recipe))
@@ -139,6 +152,13 @@ func initialLoad() -> EnvIO<Persistence, Error, State<AppState, Void>> {
             return state.copy(catalog: newCatalog, iCloudStatus: persistenceEnabled.get)
         }^
     )^
+}
+
+func generateNewRecipe(_ recipe: Recipe) -> [EnvIO<Persistence, Error, State<AppState, Void>>] {
+    [
+        EnvIO.pure(addNewRecipe(recipe))^,
+        EnvIO.pure(generatePlayground(for: .regular(recipe)))^,
+    ]
 }
 
 func fetchRecipes() -> EnvIO<Persistence, Error, [Recipe]> {

--- a/NefEditorClient/Main/Logic/MainDispatcher.swift
+++ b/NefEditorClient/Main/Logic/MainDispatcher.swift
@@ -34,11 +34,8 @@ let mainDispatcher = MainDispatcher.workflow { action in
             return []
         }
         
-    case .catalogAction(_), .editAction(_), .catalogDetailAction(_), .creditsAction(_), .generationAction(_), .faqAction(_):
+    case .catalogAction(_), .editAction(_), .catalogDetailAction(_), .creditsAction(_), .generationAction(_), .faqAction(_), .initialLoad(_):
         return []
-        
-    case .initialLoad:
-        return [initialLoad()]
     }
 }
 

--- a/NefEditorClient/Main/Logic/MainDispatcher.swift
+++ b/NefEditorClient/Main/Logic/MainDispatcher.swift
@@ -1,8 +1,8 @@
+import UIKit
 import Bow
 import BowEffects
 import BowArch
 import GitHub
-import UIKit
 
 typealias MainDispatcher = StateDispatcher<Persistence, AppState, AppAction>
 
@@ -39,9 +39,6 @@ let mainDispatcher = MainDispatcher.workflow { action in
         
     case .initialLoad:
         return [initialLoad()]
-        
-    case .schema(let recipe):
-        return generateNewRecipe(recipe)
     }
 }
 
@@ -125,14 +122,6 @@ func addDependency(
     }^
 }
 
-func addNewRecipe(_ recipe: Recipe) -> State<AppState, Void> {
-    .modify { (state: AppState) in
-        let catalogItem: CatalogItem = .regular(recipe)
-        let catalog = state.catalog.appending(catalogItem)
-        return state.copy(catalog: catalog, selectedItem: catalogItem)
-    }^
-}
-
 func persist(state: AppState) -> EnvIO<Persistence, Error, Void> {
     EnvIO.accessM { persistence in
         persistence.saveUserRecipes(state.catalog.userCreated.items.map(\.recipe))
@@ -152,13 +141,6 @@ func initialLoad() -> EnvIO<Persistence, Error, State<AppState, Void>> {
             return state.copy(catalog: newCatalog, iCloudStatus: persistenceEnabled.get)
         }^
     )^
-}
-
-func generateNewRecipe(_ recipe: Recipe) -> [EnvIO<Persistence, Error, State<AppState, Void>>] {
-    [
-        EnvIO.pure(addNewRecipe(recipe))^,
-        EnvIO.pure(generatePlayground(for: .regular(recipe)))^,
-    ]
 }
 
 func fetchRecipes() -> EnvIO<Persistence, Error, [Recipe]> {

--- a/NefEditorClient/Main/State/AppState.swift
+++ b/NefEditorClient/Main/State/AppState.swift
@@ -4,6 +4,7 @@ struct AppState: Equatable {
     let panelState: PanelState
     let modalState: AppModalState
     let searchState: SearchState
+    let deepLinkState: DeepLinkState
     let catalog: Catalog
     let selectedItem: CatalogItem?
     let iCloudStatus: ICloudStatus
@@ -14,6 +15,7 @@ struct AppState: Equatable {
         panelState: PanelState? = nil,
         modalState: AppModalState? = nil,
         searchState: SearchState? = nil,
+        deepLinkState: DeepLinkState? = nil,
         catalog: Catalog? = nil,
         selectedItem: CatalogItem?? = nil,
         iCloudStatus: ICloudStatus? = nil,
@@ -24,6 +26,7 @@ struct AppState: Equatable {
             panelState: panelState ?? self.panelState,
             modalState: modalState ?? self.modalState,
             searchState: searchState ?? self.searchState,
+            deepLinkState: deepLinkState ?? self.deepLinkState,
             catalog: catalog ?? self.catalog,
             selectedItem: selectedItem ?? self.selectedItem,
             iCloudStatus: iCloudStatus ?? self.iCloudStatus,

--- a/NefEditorClient/Main/View/AppView.swift
+++ b/NefEditorClient/Main/View/AppView.swift
@@ -71,7 +71,7 @@ struct AppView<CatalogView: View, SearchView: View, DetailView: View, ModalView:
         .onAppear {
             switch self.state.deepLinkState {
             case .none:
-                self.handle(.initialLoad())
+                self.handle(.initialLoad(.regularInitialization))
             case .recipe(let recipe):
                 self.handle(.initialLoad(.generateRecipe(recipe)))
             }

--- a/NefEditorClient/Main/View/AppView.swift
+++ b/NefEditorClient/Main/View/AppView.swift
@@ -69,9 +69,6 @@ struct AppView<CatalogView: View, SearchView: View, DetailView: View, ModalView:
             }
         }
         .navigationViewStyle(StackNavigationViewStyle())
-        .onAppear {
-            self.handle(.initialLoad)
-        }
     }
     
     var contentView: some View {

--- a/NefEditorClient/Main/View/AppView.swift
+++ b/NefEditorClient/Main/View/AppView.swift
@@ -39,8 +39,7 @@ struct AppView<CatalogView: View, SearchView: View, DetailView: View, ModalView:
                 if !newState {
                     handle(.dismissICloudAlert)
                 }
-            }
-        )
+            })
     }
     
     var showSearch: Bool {
@@ -69,6 +68,14 @@ struct AppView<CatalogView: View, SearchView: View, DetailView: View, ModalView:
             }
         }
         .navigationViewStyle(StackNavigationViewStyle())
+        .onAppear {
+            switch self.state.deepLinkState {
+            case .none:
+                self.handle(.initialLoad())
+            case .recipe(let recipe):
+                self.handle(.initialLoad(.generateRecipe(recipe)))
+            }
+        }
     }
     
     var contentView: some View {

--- a/NefEditorClient/SceneDelegate.swift
+++ b/NefEditorClient/SceneDelegate.swift
@@ -1,4 +1,3 @@
-import UIKit
 import SwiftUI
 import GitHub
 import BowArch
@@ -13,18 +12,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Remove any extra separator in the Lists
         UITableView.appearance().tableFooterView = UIView()
         
-        // Create the SwiftUI view that provides the window contents.
-        let componentView = setDeepLink(urlContexts: connectionOptions.urlContexts, componentView: appComponent())
-        loadScene(scene, contentView: componentView)
+        loadScene(scene, contentView: appComponent(deepLink: connectionOptions.urlContexts))
     }
     
     func scene(_ scene: UIScene, openURLContexts urlContexts: Set<UIOpenURLContext>) {
-        guard let windowScene = scene as? UIWindowScene,
-              let window = windowScene.windows.first,
-              let hostingController = window.rootViewController as? UIHostingController<AppComponentView> else { return }
-        
-        let componentView = setDeepLink(urlContexts: urlContexts, componentView: hostingController.rootView)
-        loadScene(scene, contentView: componentView)
+        loadScene(scene, contentView: appComponent(deepLink: urlContexts))
     }
     
     private func loadScene<V: View>(_ scene: UIScene, contentView: V) {
@@ -34,27 +26,5 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.rootViewController = UIHostingController(rootView: contentView)
         self.window = window
         window.makeKeyAndVisible()
-    }
-    
-    private func setDeepLink(urlContexts: Set<UIOpenURLContext>, componentView: AppComponentView) -> AppComponentView {
-        if let recipe = schemeRecipe(urlContexts: urlContexts) {
-            return deepLinkAppComponentLens.set(componentView, .recipe(recipe))
-        } else {
-            return deepLinkAppComponentLens.set(componentView, .none)
-        }
-    }
-    
-    private func schemeRecipe(urlContexts: Set<UIOpenURLContext>) -> Recipe? {
-        guard let url = urlContexts.first?.url,
-              let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true),
-              let action = components.host,
-              let params = components.queryItems else { return nil }
-        
-        switch action {
-        case "recipe":
-            return params.recipe
-        default:
-            return nil
-        }
     }
 }

--- a/NefEditorClient/SceneDelegate.swift
+++ b/NefEditorClient/SceneDelegate.swift
@@ -14,9 +14,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         UITableView.appearance().tableFooterView = UIView()
         
         // Create the SwiftUI view that provides the window contents.
-        let componentView = appComponent()
+        let componentView = setDeepLink(urlContexts: connectionOptions.urlContexts, componentView: appComponent())
         loadScene(scene, contentView: componentView)
-        onAppear(componentView: componentView, urlContexts: connectionOptions.urlContexts)
     }
     
     func scene(_ scene: UIScene, openURLContexts urlContexts: Set<UIOpenURLContext>) {
@@ -24,9 +23,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
               let window = windowScene.windows.first,
               let hostingController = window.rootViewController as? UIHostingController<AppComponentView> else { return }
         
-        let componentView = hostingController.rootView
+        let componentView = setDeepLink(urlContexts: urlContexts, componentView: hostingController.rootView)
         loadScene(scene, contentView: componentView)
-        onAppear(componentView: componentView, urlContexts: urlContexts)
     }
     
     private func loadScene<V: View>(_ scene: UIScene, contentView: V) {
@@ -38,11 +36,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.makeKeyAndVisible()
     }
     
-    private func onAppear(componentView: AppComponentView, urlContexts: Set<UIOpenURLContext>) {
+    private func setDeepLink(urlContexts: Set<UIOpenURLContext>, componentView: AppComponentView) -> AppComponentView {
         if let recipe = schemeRecipe(urlContexts: urlContexts) {
-            componentView.handle(.schema(recipe))
+            return deepLinkAppComponentLens.set(componentView, .recipe(recipe))
         } else {
-            componentView.handle(.initialLoad)
+            return deepLinkAppComponentLens.set(componentView, .none)
         }
     }
     

--- a/NefEditorClient/SceneDelegate.swift
+++ b/NefEditorClient/SceneDelegate.swift
@@ -29,16 +29,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         onAppear(componentView: componentView, urlContexts: urlContexts)
     }
     
-    func loadScene<V: View>(_ scene: UIScene, contentView: V) {
+    private func loadScene<V: View>(_ scene: UIScene, contentView: V) {
         guard let windowScene = scene as? UIWindowScene else { return }
             
-        let window = self.window ?? windowScene.windows.first ?? UIWindow(windowScene: windowScene)
+        let window = windowScene.windows.first ?? UIWindow(windowScene: windowScene)
         window.rootViewController = UIHostingController(rootView: contentView)
         self.window = window
         window.makeKeyAndVisible()
     }
     
-    func onAppear(componentView: AppComponentView, urlContexts: Set<UIOpenURLContext>) {
+    private func onAppear(componentView: AppComponentView, urlContexts: Set<UIOpenURLContext>) {
         if let recipe = schemeRecipe(urlContexts: urlContexts) {
             componentView.handle(.schema(recipe))
         } else {
@@ -46,9 +46,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
     
-    // MARK: - read recipe from URL scheme
-    
-    func schemeRecipe(urlContexts: Set<UIOpenURLContext>) -> Recipe? {
+    private func schemeRecipe(urlContexts: Set<UIOpenURLContext>) -> Recipe? {
         guard let url = urlContexts.first?.url,
               let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true),
               let action = components.host,
@@ -56,38 +54,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         switch action {
         case "recipe":
-            return buildRecipe(params: params)
+            return params.recipe
         default:
-            return nil
-        }
-    }
-    
-    func buildRecipe(params: [URLQueryItem]) -> Recipe? {
-        guard let title = params.first(where: { $0.name == "name" })?.value,
-              let url = params.first(where: { $0.name == "url" })?.value,
-              let requirement = buildRequirement(params: params) else { return nil }
-        
-        let description = params.first { $0.name == "description" }?.value
-        let dependency = Dependency(repository: title,
-                                    owner: "",
-                                    url: url,
-                                    avatar: "",
-                                    requirement: requirement)
-        
-        return Recipe(title: title,
-                      description: description ?? "",
-                      dependencies: [dependency])
-    }
-    
-    func buildRequirement(params: [URLQueryItem]) -> Requirement? {
-        let branch = params.first { $0.name == "branch" }?.value
-        let tag = params.first { $0.name == "tag" }?.value
-        
-        if let branch = branch {
-            return .branch(.init(name: branch))
-        } else if let tag = tag {
-            return .version(.init(name: tag))
-        } else {
             return nil
         }
     }

--- a/NefEditorClient/SceneDelegate.swift
+++ b/NefEditorClient/SceneDelegate.swift
@@ -1,6 +1,7 @@
 import UIKit
 import SwiftUI
 import GitHub
+import BowArch
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
@@ -13,9 +14,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         UITableView.appearance().tableFooterView = UIView()
         
         // Create the SwiftUI view that provides the window contents.
-        let contentView = appComponent()
-        let recipe = schemeRecipe(urlContexts: connectionOptions.urlContexts)
-        loadScene(scene, contentView: contentView)
+        let componentView = appComponent()
+        loadScene(scene, contentView: componentView)
+        onAppear(componentView: componentView, urlContexts: connectionOptions.urlContexts)
     }
     
     func scene(_ scene: UIScene, openURLContexts urlContexts: Set<UIOpenURLContext>) {
@@ -23,9 +24,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
               let window = windowScene.windows.first,
               let hostingController = window.rootViewController as? UIHostingController<AppComponentView> else { return }
         
-        let recipe = schemeRecipe(urlContexts: urlContexts)
-        let contentView = hostingController.rootView
-        loadScene(scene, contentView: contentView)
+        let componentView = hostingController.rootView
+        loadScene(scene, contentView: componentView)
+        onAppear(componentView: componentView, urlContexts: urlContexts)
     }
     
     func loadScene<V: View>(_ scene: UIScene, contentView: V) {
@@ -35,6 +36,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.rootViewController = UIHostingController(rootView: contentView)
         self.window = window
         window.makeKeyAndVisible()
+    }
+    
+    func onAppear(componentView: AppComponentView, urlContexts: Set<UIOpenURLContext>) {
+        if let recipe = schemeRecipe(urlContexts: urlContexts) {
+            componentView.handle(.schema(recipe))
+        } else {
+            componentView.handle(.initialLoad)
+        }
     }
     
     // MARK: - read recipe from URL scheme


### PR DESCRIPTION
## Details
This PR lets you build a new recipe received from scheme URL.

#### Format
- `nef-playgrounds://recipe`

#### Arguments
- `title`
- `description`*
- `repo_name`*
- `url`
- `owner`
- `avatar`
- `branch` | `tag`

> Parameters set with * are optional.

#### Example
```url
nef-playgrounds://recipe?title=Bow&url=https://github.com/bow-swift/bow.git&branch=master
```

## Implementation details
You can find a `DeepLink` module with `DeepLinkState`, `DeepLinkAction` and `DeepLinkDispatcher`.

- `AppState` contains a new property for the deep link state. 
- `AppView` can handle deep link actions.
- `DeepLinkDispatcher` contains the logic for the generation of a recipe received from a deep link.