### PR TITLE
Update Sign In disclaimer

### DIFF
--- a/NefEditorClient/Generation/View/GenerationView.swift
+++ b/NefEditorClient/Generation/View/GenerationView.swift
@@ -90,7 +90,7 @@ struct GenerationView: View {
         
     func unauthenticatedView(item: CatalogItem) -> some View {
         Group {
-            Text("In order to generate your Swift Playground, you need to sign in.")
+            Text("For security reasons, our backend connections are encrypted and verified with your Apple ID")
                 .activityStyle()
                 .padding(EdgeInsets(top: 8, leading: 0, bottom: -10, trailing: 0))
             self.signInButton(item: item)

--- a/NefEditorClient/NefEditorClient.entitlements
+++ b/NefEditorClient/NefEditorClient.entitlements
@@ -8,7 +8,7 @@
 	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:nef.bow-swift.io</string>
+		<string>applinks:badge.bow-swift.io</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>

--- a/NefEditorClient/NefEditorClientRelease.entitlements
+++ b/NefEditorClient/NefEditorClientRelease.entitlements
@@ -8,7 +8,7 @@
 	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:nef.bow-swift.io</string>
+		<string>applinks:badge.bow-swift.io</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>


### PR DESCRIPTION
This PR updates the disclaimer in the Apple sign-in screen; it gives more details on why users have to log in.