### PR TITLE
Bug in Scene

### DIFF
--- a/NefEditorClient/SceneDelegate.swift
+++ b/NefEditorClient/SceneDelegate.swift
@@ -3,6 +3,7 @@ import GitHub
 import BowArch
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // For some reason, I cannot set the background color of a SwiftUI List 🤷🏻‍♂️
@@ -28,9 +29,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     private func loadScene<V: View>(_ scene: UIScene, contentView: V) {
         guard let windowScene = scene as? UIWindowScene else { return }
-            
-        let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = UIHostingController(rootView: contentView)
-        window.makeKeyAndVisible()
+        
+        window = UIWindow(windowScene: windowScene)
+        window?.rootViewController = UIHostingController(rootView: contentView)
+        window?.makeKeyAndVisible()
     }
 }


### PR DESCRIPTION
## Details
Project is not working on **iOS14+**, it launches the next error:
```swift
Unbalanced calls to begin/end appearance transitions for <_TtGC7SwiftUI19UIHostingControllerGV7BowArch20EffectStoreComponentGC10BowEffects9IOPartialPs5Error__V3nef15AppDependenciesVS6_8AppStateOS6_9AppActionGVS6_7AppViewGS2_GS4_PS5___P_TVS6_7CatalogGSqOS6_11CatalogItem__OS6_13CatalogActionVS6_17RecipeCatalogView_GS2_GS4_PS5___VC6GitHub3API6ConfigVS6_11SearchStateOS6_12SearchActionGVS6_10SearchViewGS2_GS4_PS5___S17_OS6_16SearchModalStateOS6_22RepositoryDetailActionVS6_20RepositoryDetailView___GS2_GS4_PS5___P_S12_OS6_19CatalogDetailActionVS6_21CatalogItemDetailView_GS2_GS4_PS5___P_OS6_13AppModalStateS9_GVS6_12AppModalViewGS2_GS4_PS5___P_OS6_9EditStateOS6_10EditActionVS6_22EditRecipeMetadataView_GS2_GS4_PS5___P_OS6_15GenerationStateOS6_16GenerationActionVS6_14GenerationView_GS2_GS4_PS5___P_P_OS6_13CreditsActionVS6_11CreditsView_GS2_GS4_PS5___P_P_OS6_9FAQActionVS6_7FAQView_GS2_GS4_PS5___P_P_OS6_14WhatsNewActionVS6_12WhatsNewView______: 0x7fac3bc127e0>.
```

**Bug**: we do not retain the window.

## Scene lifecycle

Adding context to PR:

`UIScene`
```
class UIScene : UIResponder {
     var delegate: UISceneDelegate?
     ....
}
```

`UIWindow`
```
class UIWindow : UIView {
    weak var windowScene: UIWindowScene? // UIWindowScene: UIScene
    .....
}
```

`UISceneDelegate`
```
protocol UIWindowSceneDelegate : UISceneDelegate {
     var window: UIWindow? { get set }
     ....
}
```

Your App entry point is `UIWindowSceneDelegate` (coming from AppDelegate), so SO builds a scene, instance your SceneDelegate and delegate you the create/start of the window sending the created scene. If we take a screenshot to the memory at this point, you can find an `UIScene` with a **strong reference** to your entry class, kind of `UISceneDelegate`. As we have seen above, UISceneDelegate protocol is the owner to create and keep the **strong reference** to the window.