### PR TITLE
Read products in deeplink

### DIFF
--- a/NefEditorClient/Catalog/Extensions/URLQueryItem+Recipe.swift
+++ b/NefEditorClient/Catalog/Extensions/URLQueryItem+Recipe.swift
@@ -1,9 +1,6 @@
 import Foundation
 
 extension Array where Element == URLQueryItem {
-    private func value(of key: String) -> String? {
-        first { $0.name == key }?.value
-    }
     
     var recipe: Recipe? {
         guard let title = value(of: "name"),
@@ -14,7 +11,8 @@ extension Array where Element == URLQueryItem {
                      dependencies: [dependency])
     }
     
-    var dependency: Dependency? {
+    // MARK: Recipe <helpers>
+    private var dependency: Dependency? {
         guard let repository = value(of: "name"),
               let url = value(of: "url"),
               let owner = value(of: "owner"),
@@ -25,10 +23,11 @@ extension Array where Element == URLQueryItem {
                      owner: owner,
                      url: url,
                      avatar: avatar,
-                     requirement: requirement)
+                     requirement: requirement,
+                     products: products)
     }
     
-    var requirement: Requirement? {
+    private var requirement: Requirement? {
         if let branch = value(of: "branch") {
             return .branch(.init(name: branch))
         } else if let tag = value(of: "tag") {
@@ -36,5 +35,20 @@ extension Array where Element == URLQueryItem {
         } else {
             return nil
         }
+    }
+    
+    private var products: Dependency.Products {
+        let products = values(of: "products").map { $0.trimmingCharacters(in: .whitespaces) }
+        return products.count > 0 ? .selected(names: products) : .all
+    }
+    
+    // MARK: URLQueryItem <helpers>
+    private func value(of key: String) -> String? {
+        first { $0.name == key }?.value
+    }
+    
+    private func values(of key: String) -> [String] {
+        filter { $0.name == "\(key)[]" }
+            .compactMap(\.value)
     }
 }

--- a/NefEditorClient/Catalog/State/Catalog.swift
+++ b/NefEditorClient/Catalog/State/Catalog.swift
@@ -20,7 +20,8 @@ struct Catalog: Equatable {
                             owner: "bow-swift",
                             url: "https://github.com/bow-swift/bow",
                             avatar: "https://avatars3.githubusercontent.com/u/44965417?v=4",
-                            requirement: .version(Tag(name: "0.8.0")))
+                            requirement: .version(Tag(name: "0.8.0")),
+                            products: .all)
                 ]),
                 backgroundImage: "bow-background",
                 textColor: .white)
@@ -37,7 +38,8 @@ struct Catalog: Equatable {
                             owner: "bow-swift",
                             url: "https://github.com/bow-swift/bow-arch",
                             avatar: "https://avatars3.githubusercontent.com/u/44965417?v=4",
-                            requirement: .branch(Branch(name: "0.1.0")))
+                            requirement: .branch(Branch(name: "0.1.0")),
+                            products: .all)
                 ]),
                 backgroundImage: "bow-arch-background",
                 textColor: .black)
@@ -54,7 +56,8 @@ struct Catalog: Equatable {
                             owner: "bow-swift",
                             url: "https://github.com/bow-swift/bow-lite",
                             avatar: "https://avatars3.githubusercontent.com/u/44965417?v=4",
-                            requirement: .version(Tag(name: "0.1.0")))
+                            requirement: .version(Tag(name: "0.1.0")),
+                            products: .all)
                 ]),
                 backgroundImage: "bow-lite-background",
                 textColor: .white)

--- a/NefEditorClient/Catalog/State/Dependency.swift
+++ b/NefEditorClient/Catalog/State/Dependency.swift
@@ -1,11 +1,51 @@
-struct Dependency: Equatable, Codable, Identifiable {
+struct Dependency: Equatable, Identifiable {
+    enum Products: Equatable {
+        case all
+        case selected(names: [String])
+    }
+    
     let repository: String
     let owner: String
     let url: String
     let avatar: String
     let requirement: Requirement
+    let products: Products
     
     var id: String {
         "\(url):\(requirement.id)"
+    }
+}
+
+// MARK: - Codable
+
+extension Dependency: Codable { }
+
+extension Dependency.Products: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case all
+        case selected
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .all:
+            try container.encode([String](), forKey: .all)
+        case .selected(let products):
+            try container.encode(products, forKey: .selected)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        if let _ = try? container.decode([String].self, forKey: .all) {
+            self = .all
+        } else if let products = try? container.decode([String].self, forKey: .selected) {
+            self = .selected(names: products)
+        } else {
+            fatalError("Dependency.Product decoding could not find a valid key.")
+        }
     }
 }

--- a/NefEditorClient/Catalog/State/Dependency.swift
+++ b/NefEditorClient/Catalog/State/Dependency.swift
@@ -40,12 +40,10 @@ extension Dependency.Products: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        if let _ = try? container.decode([String].self, forKey: .all) {
-            self = .all
-        } else if let products = try? container.decode([String].self, forKey: .selected) {
+        if let products = try? container.decode([String].self, forKey: .selected) {
             self = .selected(names: products)
         } else {
-            fatalError("Dependency.Product decoding could not find a valid key.")
+            self = .all
         }
     }
 }

--- a/NefEditorClient/Generation/Logic/GenerationDispatcher.swift
+++ b/NefEditorClient/Generation/Logic/GenerationDispatcher.swift
@@ -133,7 +133,9 @@ func dependencyToPlaygroundDependency(_ dependency: Dependency) -> PlaygroundDep
     PlaygroundDependency(
         name: dependency.repository,
         url: dependency.url,
-        requirement: requirementToPlaygroundRequirement(dependency.requirement))
+        requirement: requirementToPlaygroundRequirement(dependency.requirement),
+        products: productsToPlaygroundProducts(dependency.products)
+    )
 }
 
 func requirementToPlaygroundRequirement(_ requirement: Requirement) -> PlaygroundDependency.Requirement {
@@ -142,6 +144,15 @@ func requirementToPlaygroundRequirement(_ requirement: Requirement) -> Playgroun
         return .branch(branch.name)
     case .version(let tag):
         return .version(tag.name)
+    }
+}
+
+func productsToPlaygroundProducts(_ products: Dependency.Products) -> [String] {
+    switch products {
+    case .all:
+        return []
+    case .selected(let names):
+        return names
     }
 }
 

--- a/NefEditorClient/Main/Logic/MainDispatcher.swift
+++ b/NefEditorClient/Main/Logic/MainDispatcher.swift
@@ -116,7 +116,8 @@ func addDependency(
                                         owner: repository.owner.login,
                                         url: repository.htmlUrl,
                                         avatar: repository.owner.avatarUrl,
-                                        requirement: requirement)
+                                        requirement: requirement,
+                                        products: .all)
             let newRecipe = selected.appending(dependency: dependency)
             
             return state.copy(

--- a/NefEditorClient/Preview Content/PreviewData.swift
+++ b/NefEditorClient/Preview Content/PreviewData.swift
@@ -38,14 +38,16 @@ let bowDependency = Dependency(
     owner: "bow-swift",
     url: "https://github.com/bow-swift/bow",
     avatar: "https://avatars3.githubusercontent.com/u/44965417?v=4",
-    requirement: .version(Tag(name: "0.7.0")))
+    requirement: .version(Tag(name: "0.7.0")),
+    products: .all)
 
 let bowArchDependency = Dependency(
     repository: "bow-arch",
     owner: "bow-swift",
     url: "https://github.com/bow-swift/bow-arch",
     avatar: "https://avatars3.githubusercontent.com/u/44965417?v=4",
-    requirement: .branch(Branch(name: "master")))
+    requirement: .branch(Branch(name: "0.1.0")),
+    products: .all)
 
 let sampleRecipe = Recipe(
     title: "FP Basics",

--- a/NefEditorClient/Preview Content/PreviewData.swift
+++ b/NefEditorClient/Preview Content/PreviewData.swift
@@ -38,7 +38,7 @@ let bowDependency = Dependency(
     owner: "bow-swift",
     url: "https://github.com/bow-swift/bow",
     avatar: "https://avatars3.githubusercontent.com/u/44965417?v=4",
-    requirement: .version(Tag(name: "0.7.0")),
+    requirement: .version(Tag(name: "0.8.0")),
     products: .all)
 
 let bowArchDependency = Dependency(


### PR DESCRIPTION
### Details
Currently, we are generating Swift Playgrounds for the whole products of each library, but the last [nef-editor-server](https://github.com/bow-swift/nef-editor-server/pull/23) release has added support to filter by-products. This PR takes advantage of this new feature, and add support about products filtering to deep links and featured card.

----------

Example of use:

```
https://badge.bow-swift.io/recipe?name=bow
&description=Bow%20is%20a%20cross-platform%20library%20for%20Typed%20Functional%20Programming%20in%20Swift
&url=https://github.com/bow-swift/bow
&owner=bow-swift
&avatar=https://avatars3.githubusercontent.com/u/44965417?v=4
&branch=master
&products[]=BowEffects
```

> It will generate a Swift Playground for the library Bow, adding only the product BowEffects (and its dependencies)